### PR TITLE
Move httpclient to compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>4.3.5</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Some plugins might require httpclient. For example, AWS SDK uses httpclient.
Forcing it with a test scope would force adding in `cloud-aws` `pom.xml` file the following:

```xml
<dependency>
  <groupId>org.apache.httpcomponents</groupId>
  <artifactId>httpclient</artifactId>
  <scope>compile</scope>
</dependency>
```

It would be better to force in elasticsearch core project the `test` scope.